### PR TITLE
Update msg.go

### DIFF
--- a/protocol/msg.go
+++ b/protocol/msg.go
@@ -75,7 +75,7 @@ func NewMessage(cmd, network string, payload interface{}) (*Message, error) {
 
 // CommandString returns command as a string with zero bytes removed.
 func (mh MessageHeader) CommandString() string {
-	return strings.Trim(string(mh.Command[:]), string(0))
+	return strings.Trim(string(mh.Command[:]), string(byte(0)))
 }
 
 // Validate ...


### PR DESCRIPTION
conversion from untyped int to string yields a string of one rune, not a string of digits.